### PR TITLE
update Makefile based on Skeleton; minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.cm*
+.depend
+.Makefile.plugin.generated
+*.check_mli_exists

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,32 @@
-FRAMAC_SHARE := $(shell frama-c-config -print-share-path)
-FRAMAC_LIBDIR := $(shell frama-c-config -print-libpath)
+### Setting up the environment (DO NOT MODIFY THESE LINES) ###
+ifndef FRAMAC_SHARE                                          #
+FRAMAC_SHARE := $(shell frama-c-config -print-share-path)    #
+endif                                                        #
+ifndef FRAMAC_LIBDIR                                         #
+FRAMAC_LIBDIR := $(shell frama-c-config -print-libpath)      #
+endif                                                        #
+PLUGIN_DIR ?=.                                               #
+##############################################################
+
+# PLUGIN_NAME must not contain hyphens or spaces
 PLUGIN_NAME = Hello
+
+# List of .cmo files (usually one per .ml)
 PLUGIN_CMO = hello_options hello_print hello_run
+
+# Test directories must be below $PLUGIN_DIR/tests
 PLUGIN_TESTS_DIRS := hello
+
+# After everything is set, include Frama-C's Makefile for plug-ins
 include $(FRAMAC_SHARE)/Makefile.dynamic
+
+### Note: if your plug-in has a [Makefile.in], uncomment the lines below.
+#
+#ifeq ("$(FRAMAC_INTERNAL)","yes")
+#CONFIG_STATUS_DIR=$(FRAMAC_SRC)
+#else
+#CONFIG_STATUS_DIR=.
+#endif
+#$(Hello_DIR)/Makefile: $(Hello_DIR)/Makefile.in \
+#                       $(CONFIG_STATUS_DIR)/config.status
+#	cd $(CONFIG_STATUS_DIR) && ./config.status --file $@

--- a/tests/hello/result/hello_test.res.log
+++ b/tests/hello/result/hello_test.res.log
@@ -1,3 +1,2 @@
-[kernel] Parsing FRAMAC_SHARE/libc/__fc_builtin_for_normalization.i (no preprocessing)
 [kernel] Parsing tests/hello/hello_test.c (with preprocessing)
 [hello] Hello, world!

--- a/tests/ptests_config
+++ b/tests/ptests_config
@@ -1,8 +1,0 @@
-DEFAULT_SUITES= hello
-TOPLEVEL_PATH=/Users/tantignac/.opam/system/bin/frama-c
-FRAMAC_SHARE=/Users/tantignac/.opam/system/share/frama-c
-FRAMAC_LIB=/Users/tantignac/.opam/system/lib/frama-c
-FRAMAC_PLUGIN=.:/Users/tantignac/.opam/system/lib/frama-c/plugins
-FRAMAC_PLUGIN_GUI=./gui:/Users/tantignac/.opam/system/lib/frama-c/plugins/gui
-OCAMLFIND_IGNORE_DUPS_IN=/Users/tantignac/.opam/system/lib/frama-c/plugins
-OCAMLRUNPARAM=


### PR DESCRIPTION
This should bring Hello and Skeleton closer, and while not ideal, it should in theory allow new plug-ins to be as close as possible to the "actual" Makefiles of internal plug-ins.

In particular, one issue that remains is the fact that "real" plug-ins always have a `Makefile.in` file, which is processed by `autoconf` to produce the `Makefile`. But for the `Hello` tutorial this is overkill, so only a `Makefile` is given. I left a commented out section so that users will know what to do if one day they decide to switch, but I find it quite unappealing: it should only be present in Skeleton, not Hello.

For the rest, tell me if the comments are not clear or if you prefer to present then differently. For instance, there is an "immutable" block in the beginning, which I tried to visually separate from the rest, so that users will not bother with it.

Also, I removed `ptests_config` from the versioning because it is a generated file (and it leaks personal information! :tongue: for instance it tells us that you used a Mac to generate it, with OPAM using a system compiler (probably via Homebrew)).